### PR TITLE
fix: add database and Redis connection environment variables to proce…

### DIFF
--- a/deployments/k3s/manifests/k3s-processor-deployment-gpu.yaml
+++ b/deployments/k3s/manifests/k3s-processor-deployment-gpu.yaml
@@ -39,6 +39,22 @@ spec:
           value: "compute,utility"
         - name: CUDA_VISIBLE_DEVICES
           value: "0"
+        # Database connection
+        - name: DATABASE_HOST
+          value: "postgresql-pgvector.sejm-whiz"
+        - name: DATABASE_PORT
+          value: "5432"
+        - name: DATABASE_NAME
+          value: "sejm_whiz"
+        - name: DATABASE_USER
+          value: "sejm_whiz"
+        - name: DATABASE_PASSWORD
+          value: "sejm_whiz_password"
+        # Redis connection
+        - name: REDIS_HOST
+          value: "redis.sejm-whiz"
+        - name: REDIS_PORT
+          value: "6379"
         # Application-specific environment
         - name: EMBEDDING_DEVICE
           value: "cuda"


### PR DESCRIPTION
…ssor deployment

The processor was failing with CrashLoopBackOff due to attempting to connect to localhost:5432 instead of the PostgreSQL service. Added proper environment variables to connect to the cluster services:
- DATABASE_HOST points to postgresql-pgvector.sejm-whiz service
- REDIS_HOST points to redis.sejm-whiz service
- Added all required database credentials

This fixes the processor deployment and enables successful document processing with GPU acceleration.

🤖 Generated with [Claude Code](https://claude.ai/code)