### PR TITLE
ui: reduce dashboard live logs window height to 60% of original size

### DIFF
--- a/bases/sejm_whiz/web_api/templates/dashboard.html
+++ b/bases/sejm_whiz/web_api/templates/dashboard.html
@@ -109,7 +109,7 @@
             padding: 20px;
             box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
             min-height: 500px;
-            max-height: 70vh;
+            max-height: 42vh;
             display: flex;
             flex-direction: column;
         }


### PR DESCRIPTION
## Summary
- Reduced log container height from 70vh to 42vh (60% of original size)
- Maintains all auto-scroll and interactive functionality
- Makes dashboard more compact and user-friendly

## Test plan
- [ ] Verify dashboard loads correctly at reduced height
- [ ] Test auto-scroll functionality still works properly
- [ ] Confirm log content remains readable and accessible

🤖 Generated with [Claude Code](https://claude.ai/code)